### PR TITLE
Guard cache ttl field with cfg macro and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Text Format**: Plain text configuration support with automatic detection via `.txt` extensions
   - **Properties Format**: Enhanced existing properties format support (default when no extension is specified)
 - **Automatic Format Detection**: Intelligent namespace format detection based on file extensions in namespace names
-- **Cache TTL Support**: Added Time-To-Live (TTL) mechanism for cache expiration:
-  - New `cache_ttl` field in `ClientConfig` struct
+- **Cache TTL Support**: Added Time-To-Live (TTL) mechanism for cache expiration (native targets only):
+  - New `cache_ttl` field in `ClientConfig` struct (native targets only)
   - Default TTL of 600 seconds (10 minutes) when using `from_env()`
-  - Configurable via `APOLLO_CACHE_TTL` environment variable
+  - Configurable via `APOLLO_CACHE_TTL` environment variable (native targets only)
   - Automatic cache refresh when TTL expires
 - **Enhanced Namespace System**: Complete refactoring of the namespace module with:
   - Unified `Namespace` enum supporting all configuration formats
@@ -86,8 +86,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API Documentation**: Complete API reference with examples
 - **Multi-language Support**: Documentation available in English, Simplified Chinese, and Traditional Chinese
 - **Documentation Updates**: Recent improvements including:
-  - Added `cache_ttl` field documentation in all code examples
-  - Updated README files to include `APOLLO_CACHE_TTL` environment variable
+  - Added `cache_ttl` field documentation in all code examples (native targets only)
+  - Updated README files to include `APOLLO_CACHE_TTL` environment variable (native targets only)
   - Enhanced error handling documentation for namespace formats
   - Improved text format support with proper error handling
   - Better documentation for unsupported XML format

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cache_dir: None, // Uses default: /opt/data/{app_id}/config-cache
         label: None,     // For grayscale releases
         ip: None,        // For grayscale releases
-        cache_ttl: None, // Uses default: 600 seconds (10 minutes)
+        #[cfg(not(target_arch = "wasm32"))]
+cache_ttl: None, // Uses default: 600 seconds (10 minutes)
     };
 
     let mut client = Client::new(client_config);
@@ -136,7 +137,7 @@ let client_config = ClientConfig::from_env()?;
 - `APOLLO_ACCESS_KEY_SECRET`: The secret key for authentication (optional)
 - `APOLLO_LABEL`: Comma-separated list of labels for grayscale rules (optional)
 - `APOLLO_CACHE_DIR`: Directory to store local cache (optional)
-- `APOLLO_CACHE_TTL`: Time-to-live for cache in seconds (optional, defaults to 600)
+- `APOLLO_CACHE_TTL`: Time-to-live for cache in seconds (optional, defaults to 600, native targets only)
 
 ### JavaScript/WebAssembly Usage
 
@@ -338,6 +339,7 @@ let client_config = ClientConfig {
     cache_dir: None,
     label: Some("canary,beta".to_string()),  // Multiple labels
     ip: Some("192.168.1.100".to_string()),  // Client IP
+    #[cfg(not(target_arch = "wasm32"))]
     cache_ttl: None,
 };
 ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -63,7 +63,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cache_dir: None, // 使用默认值: /opt/data/{app_id}/config-cache
         label: None,     // 用于灰度发布
         ip: None,        // 用于灰度发布
-        cache_ttl: None, // 使用默认值: 600 秒（10 分钟）
+        #[cfg(not(target_arch = "wasm32"))]
+cache_ttl: None, // 使用默认值: 600 秒（10 分钟）
     };
 
     let mut client = Client::new(client_config);
@@ -136,7 +137,7 @@ let client_config = ClientConfig::from_env()?;
 - `APOLLO_ACCESS_KEY_SECRET`: 认证密钥（可选）
 - `APOLLO_LABEL`: 灰度规则的标签列表，用逗号分隔（可选）
 - `APOLLO_CACHE_DIR`: 本地缓存目录（可选）
-- `APOLLO_CACHE_TTL`: 缓存生存时间，以秒为单位（可选，默认为 600）
+- `APOLLO_CACHE_TTL`: 缓存生存时间，以秒为单位（可选，默认为 600，仅限原生目标）
 
 ### JavaScript/WebAssembly 用法
 
@@ -338,6 +339,7 @@ let client_config = ClientConfig {
     cache_dir: None,
     label: Some("canary,beta".to_string()),  // 多个标签
     ip: Some("192.168.1.100".to_string()),  // 客户端 IP
+    #[cfg(not(target_arch = "wasm32"))]
     cache_ttl: None,
 };
 ```

--- a/docs/wiki/en/Configuration.md
+++ b/docs/wiki/en/Configuration.md
@@ -132,15 +132,17 @@ let config = ClientConfig {
 };
 ```
 
-#### `cache_ttl` (Option<u64>)
+#### `cache_ttl` (Option<u64>) - Native targets only
 
 - **Description**: Time-to-live for the file cache in seconds.
 - **Purpose**: Prevents the client from using a stale cache.
 - **Default**: When using `from_env`, this defaults to 600 seconds (10 minutes) if the `APOLLO_CACHE_TTL` environment variable is not set.
 - **Environment Variable**: `APOLLO_CACHE_TTL`
+- **Platform Support**: This field is only available on native targets (not WebAssembly) as disk caching is not supported in WASM environments.
 
 ```rust
 let config = ClientConfig {
+    #[cfg(not(target_arch = "wasm32"))]
     cache_ttl: Some(300), // 5 minutes
     // ... other fields
 };
@@ -222,7 +224,7 @@ let config = ClientConfig::from_env()?;
 - **`APOLLO_ACCESS_KEY_SECRET`**: The secret key for authentication (optional)
 - **`APOLLO_LABEL`**: Comma-separated list of labels for grayscale rules (optional)
 - **`APOLLO_CACHE_DIR`**: Directory to store local cache (optional)
-- **`APOLLO_CACHE_TTL`**: Time-to-live for the cache in seconds (optional, defaults to 600)
+- **`APOLLO_CACHE_TTL`**: Time-to-live for the cache in seconds (optional, defaults to 600, native targets only)
 
 #### Setting Environment Variables
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -256,11 +256,15 @@ impl Cache {
                     if let Ok(file) = std::fs::File::open(&file_path) {
                         if let Ok(cache_item) = serde_json::from_reader::<_, CacheItem>(file) {
                             let mut is_stale = false;
-                            if let Some(ttl) = self.client_config.cache_ttl {
-                                let age = Utc::now().timestamp() - cache_item.timestamp;
-                                if age > ttl as i64 {
-                                    is_stale = true;
-                                    trace!("Cache for {} is stale.", self.namespace);
+                            cfg_if::cfg_if! {
+                                if #[cfg(not(target_arch = "wasm32"))] {
+                                    if let Some(ttl) = self.client_config.cache_ttl {
+                                        let age = Utc::now().timestamp() - cache_item.timestamp;
+                                        if age > ttl as i64 {
+                                            is_stale = true;
+                                            trace!("Cache for {} is stale.", self.namespace);
+                                        }
+                                    }
                                 }
                             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //!     cache_dir: None,
 //!     label: None,
 //!     ip: None,
+//!     #[cfg(not(target_arch = "wasm32"))]
 //!     cache_ttl: None,
 //! };
 //!
@@ -98,6 +99,7 @@ pub mod namespace;
 /// #     cache_dir: None,
 /// #     label: None,
 /// #     ip: None,
+/// #     #[cfg(not(target_arch = "wasm32"))]
 /// #     cache_ttl: None,
 /// # });
 /// match client.namespace("application").await {
@@ -204,6 +206,7 @@ cfg_if::cfg_if! {
 ///     cache_dir: None,
 ///     label: None,
 ///     ip: None,
+///     #[cfg(not(target_arch = "wasm32"))]
 ///     cache_ttl: None,
 /// };
 ///
@@ -231,6 +234,7 @@ cfg_if::cfg_if! {
 /// #     cache_dir: None,
 /// #     label: None,
 /// #     ip: None,
+/// #     #[cfg(not(target_arch = "wasm32"))]
 /// #     cache_ttl: None,
 /// # };
 /// # let client = Client::new(config);
@@ -521,6 +525,7 @@ mod tests {
                 secret: None,
                 cache_dir: Some(String::from("/tmp/apollo")),
                 ip: None,
+                #[cfg(not(target_arch = "wasm32"))]
                 cache_ttl: None,
             };
             Client::new(config)
@@ -534,6 +539,7 @@ mod tests {
                 secret: Some(String::from("53bf47631db540ac9700f0020d2192c8")),
                 cache_dir: Some(String::from("/tmp/apollo")),
                 ip: None,
+                #[cfg(not(target_arch = "wasm32"))]
                 cache_ttl: None,
             };
             Client::new(config)
@@ -547,6 +553,7 @@ mod tests {
                 secret: None,
                 cache_dir: Some(String::from("/tmp/apollo")),
                 ip: Some(String::from("1.2.3.4")),
+                #[cfg(not(target_arch = "wasm32"))]
                 cache_ttl: None,
             };
             Client::new(config)
@@ -560,6 +567,7 @@ mod tests {
                 secret: None,
                 cache_dir: Some(String::from("/tmp/apollo")),
                 ip: None,
+                #[cfg(not(target_arch = "wasm32"))]
                 cache_ttl: None,
             };
             Client::new(config)
@@ -1057,6 +1065,7 @@ mod tests {
             secret: None,
             label: None,
             ip: None,
+            #[cfg(not(target_arch = "wasm32"))]
             cache_ttl: None,
             // ..Default::default() // Be careful with Default if it doesn't set all needed fields for tests
         };


### PR DESCRIPTION
Guard `cache_ttl` field with `cfg` macro to exclude it from WASM builds and update documentation accordingly.

The `cache_ttl` field is irrelevant for WASM targets as disk caching is not supported in those environments. This change ensures that the field and its associated logic are only compiled for native targets, reducing WASM bundle size and providing clearer, platform-specific documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1355847-068b-4372-9b10-5c248e898d78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a1355847-068b-4372-9b10-5c248e898d78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>